### PR TITLE
Fix init function prototypes in main.h

### DIFF
--- a/main/main.h
+++ b/main/main.h
@@ -20,10 +20,9 @@
 static esp_err_t init_nvs(void);
 
 /**
- * @brief Initialize all system components
+ * @brief Initialize sensor system (I2C bus and SCD30 sensor)
  * @return ESP_OK if successful, otherwise error code
  */
-static esp_err_t init_nvs(void);
 static esp_err_t init_sensor_system(void);
 
 // Function declarations


### PR DESCRIPTION
## Summary
- remove duplicate prototype for `init_nvs`
- clarify comment and add newline at EOF

## Testing
- `idf.py --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843c9f188b8832ab6db14ccdfbc5cf6