### PR TITLE
Fix probe init order

### DIFF
--- a/main/components/i2c_handler/i2c_handler.c
+++ b/main/components/i2c_handler/i2c_handler.c
@@ -102,13 +102,15 @@ esp_err_t i2c_handler_init(void)
   
     vTaskDelay(pdMS_TO_TICKS(100));
 
+    // Set the initialization flag before probing so the probe can run
+    is_initialized = true;
+
     // Attempting to probe the SCD30 device
     ret = i2c_handler_probe_device(SCD30_SENSOR_ADDR);  // <-- Provide the address as an argument
     if (ret != ESP_OK) {
         ESP_LOGW(TAG, "Device probe failed for address 0x%02x, but continuing anyway", SCD30_SENSOR_ADDR);
     }
 
-    is_initialized = true;
     return ESP_OK;
 }
 


### PR DESCRIPTION
## Summary
- initialize I2C handler before calling the probe function so probe succeeds

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843cd2226a0832abd41bde5c6ff19d6