### PR TITLE
Simplify SCD30 init

### DIFF
--- a/main/components/scd30_driver/scd30_driver.h
+++ b/main/components/scd30_driver/scd30_driver.h
@@ -38,7 +38,7 @@
 #define SCD30_CMD_AUTO_SELF_CALIBRATION 0x5306 /*!< (De)Activate self-calibration (ASC), Format: uint16 “1”: Activate ASC, “0”: Deactivate continuous ASC*/
 
 /* Configuration Values */
-#define SCD30_MEASUREMENT_INTERVAL  5       /*!< Measurement interval in seconds */
+#define SCD30_MEASUREMENT_INTERVAL  2       /*!< Measurement interval in seconds */
 #define SCD30_AMBIENT_PRESSURE     1013    /*!< Default ambient pressure in mbar */
 #define SCD30_DEFAULT_ALTITUDE     500     /*!< Default altitude in meters */
 #define SCD30_HW_TEMP_OFFSET      2.5f    /*!< Hardware temperature offset in °C */


### PR DESCRIPTION
## Summary
- implement a streamlined `scd30_init` based on Adafruit sequence
- set default measurement interval to 2 seconds

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db6a96c2c832abb2edf5a1f488a4e