### PR TITLE
Add SCD30 warmup delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ The SCD30 sensor is configured with:
 - Temperature offset compensation
 - Optional altitude/pressure compensation
 - Automatic error recovery and sensor reset capabilities
+- Requires a warm-up delay (`SCD30_WARMUP_TIME_MS`) after starting continuous
+  measurement before valid readings are available
 
 ## Project Structure
 

--- a/main/components/scd30_driver/scd30_driver.c
+++ b/main/components/scd30_driver/scd30_driver.c
@@ -301,6 +301,9 @@ static void scd30_measurement_task(void *pvParameters)
         return;
     }
 
+    // Give the sensor time to warm up before reading data
+    vTaskDelay(pdMS_TO_TICKS(SCD30_WARMUP_TIME_MS));
+
     while (task_running) {
         ret = scd30_read_measurement(&measurement, false);
         if (ret == ESP_OK) {


### PR DESCRIPTION
## Summary
- give the SCD30 sensor time to warm up before reading measurements
- mention the warm-up period in documentation

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dbd2a1d1c832abb591540992cdd0b