### PR TITLE
Improve I2C recovery logging

### DIFF
--- a/main/components/i2c_handler/i2c_handler.c
+++ b/main/components/i2c_handler/i2c_handler.c
@@ -20,8 +20,8 @@
  /* Function prototypes */
  static esp_err_t i2c_handler_recover_bus(void);
  
- static esp_err_t i2c_handler_recover_bus(void)
- {
+static esp_err_t i2c_handler_recover_bus(void)
+{
      ESP_LOGW(TAG, "Attempting I2C bus recovery...");
      
      // Configure SCL and SDA as GPIO
@@ -54,9 +54,17 @@
      gpio_reset_pin(I2C_MASTER_SCL_IO);
      gpio_reset_pin(I2C_MASTER_SDA_IO);
  
-     ESP_LOGI(TAG, "I2C bus recovery completed");
-     return ESP_OK;
- }
+    ESP_LOGI(TAG, "I2C bus recovery completed");
+    return ESP_OK;
+}
+
+esp_err_t i2c_handler_recover(void)
+{
+    if (!is_initialized) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    return i2c_handler_recover_bus();
+}
  
  esp_err_t i2c_handler_init(void)
  {

--- a/main/components/i2c_handler/i2c_handler.h
+++ b/main/components/i2c_handler/i2c_handler.h
@@ -96,3 +96,14 @@ esp_err_t i2c_handler_probe_device(uint8_t address);
  * @brief Scan the I2C bus for connected devices and log their addresses
  */
 void i2c_scan(void);
+
+/**
+ * @brief Attempt to recover the I2C bus
+ *
+ * This will toggle the clock line and generate a STOP condition in
+ * order to release any stuck devices. It can be called after a
+ * communication error has occurred.
+ *
+ * @return ESP_OK if the recovery sequence ran, otherwise error code
+ */
+esp_err_t i2c_handler_recover(void);


### PR DESCRIPTION
## Summary
- add `i2c_handler_recover()` API for recovering a stuck I2C bus
- log raw sensor bytes and attempt bus recovery on CRC failure
- recover bus on communication errors and convert SCD30 words via memcpy for strict-aliasing compliance

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684df6c05b40832a9beef129e4226024