### PR TITLE
Fix CRC and add Q_sensor compatibility

### DIFF
--- a/main/components/scd30_driver/scd30_driver.c
+++ b/main/components/scd30_driver/scd30_driver.c
@@ -30,25 +30,24 @@
  static bool task_running = false;
  
  /* CRC calculation for SCD30 communication */
- static uint8_t scd30_crc8(const uint8_t *data, size_t len)
- {
-     // This CRC-8 calculation is based on the SCD30 datasheet and Adafruit's implementation.
-     const uint8_t POLYNOMIAL = 0x31;
-     uint8_t crc = 0xFF;
- 
-     for (size_t j = 0; j < len; ++j) {
-         crc ^= data[j];
- 
-         for (uint8_t bit = 0; bit < 8; ++bit) {
-             if (crc & 0x80) {
-                 crc = (crc << 1) ^ POLYNOMIAL;
-             } else {
-                 crc <<= 1;
-             }
-         }
-     }
-     return crc;
- }
+static uint8_t scd30_crc8(const uint8_t *data, size_t len)
+{
+    /* CRC-8 formula from the SCD30 datasheet.  Implementation mirrors the
+     * Adafruit library to ensure interoperability.  Test data 0xBE 0xEF should
+     * yield 0x92.
+     */
+    const uint8_t POLYNOMIAL = 0x31;
+    uint8_t crc = 0xFF;
+
+    for (size_t j = 0; j < len; j++) {
+        crc ^= data[j];
+        for (uint8_t i = 0; i < 8; i++) {
+            crc = (crc & 0x80) ? (crc << 1) ^ POLYNOMIAL : (crc << 1);
+        }
+    }
+
+    return crc;
+}
  
  /* Send command to SCD30 */
  static esp_err_t scd30_send_command(uint16_t command, const uint16_t *data, size_t words)

--- a/main/components/zigbee_handler/zigbee_handler.c
+++ b/main/components/zigbee_handler/zigbee_handler.c
@@ -13,6 +13,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/event_groups.h"
 #include "app_defs.h"
+#include "main.h"
 #include "i2c_handler.h"
 #include "scd30_driver.h"
 #include "string.h"
@@ -868,4 +869,48 @@ esp_err_t zigbee_handler_reconnect(void)
     }
     
     return ESP_OK;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Compatibility wrappers matching the Q_sensor API                            */
+/* -------------------------------------------------------------------------- */
+
+void zigbee_setup(void)
+{
+    ESP_LOGI(TAG, "zigbee_setup() wrapper called");
+    zigbee_handler_start();
+}
+
+void update_attributes(attribute_t attribute)
+{
+    if (attribute == ATTRIBUTE_ALL || attribute == ATTRIBUTE_SCD) {
+        scd30_measurement_t m;
+        if (scd30_read_measurement(&m, false) == ESP_OK) {
+            zigbee_handler_update_measurements(m.co2_ppm, m.temperature, m.humidity);
+        } else {
+            ESP_LOGW(TAG, "update_attributes: failed to read measurement");
+        }
+    }
+}
+
+void send_bin_cfg_option(int endpoint, bool value) {
+    ESP_LOGI(TAG, "send_bin_cfg_option stub called (endpoint %d, value %d)", endpoint, value);
+}
+
+void send_zone_1_state(uint8_t bit_index, uint8_t value) {
+    ESP_LOGI(TAG, "send_zone_1_state stub called (bit %d, value %d)", bit_index, value);
+}
+
+void force_update_task(void) {
+    ESP_LOGI(TAG, "force_update_task stub executed");
+    update_attributes(ATTRIBUTE_ALL);
+}
+
+void force_update(void) {
+    ESP_LOGI(TAG, "force_update stub executed");
+    update_attributes(ATTRIBUTE_ALL);
+}
+
+void read_server_time(void) {
+    ESP_LOGI(TAG, "read_server_time stub called");
 }

--- a/main/components/zigbee_handler/zigbee_handler.h
+++ b/main/components/zigbee_handler/zigbee_handler.h
@@ -155,3 +155,25 @@ esp_err_t zigbee_handler_cleanup(void);
  * @return ESP_OK if reconnection procedure started, error code otherwise
  */
 esp_err_t zigbee_handler_reconnect(void);
+
+/* -------------------------------------------------------------------------- */
+/* Compatibility wrappers matching the Q_sensor API                            */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @brief Wrapper matching Q_sensor's zigbee_setup() function.
+ */
+void zigbee_setup(void);
+
+/**
+ * @brief Wrapper matching Q_sensor's update_attributes() function.
+ *        Currently only updates the SCD30 measurements.
+ */
+void update_attributes(attribute_t attribute);
+
+/** Compatibility stubs for functions used in Q_sensor but not implemented. */
+void send_bin_cfg_option(int endpoint, bool value);
+void send_zone_1_state(uint8_t bit_index, uint8_t value);
+void force_update_task(void);
+void force_update(void);
+void read_server_time(void);

--- a/main/main.h
+++ b/main/main.h
@@ -14,6 +14,15 @@
 #include "stdbool.h"
 
 /**
+ * @brief Enumeration used by the Q_sensor project to select which attributes
+ *        to update when sending measurements over Zigbee.
+ */
+typedef enum {
+    ATTRIBUTE_ALL,  /*!< Update all available attributes */
+    ATTRIBUTE_SCD,  /*!< Update SCD30 related attributes only */
+} attribute_t;
+
+/**
  * @brief Initialize non-volatile storage
  * @return ESP_OK if successful, otherwise error code
  */


### PR DESCRIPTION
## Summary
- implement CRC function mirroring Adafruit's code
- expose Q_sensor API wrappers for Zigbee
- add minimal attribute enum to match Q_sensor

## Testing
- `idf.py --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e6c408154832a96d57dd31f9fb806